### PR TITLE
Better Dragging Behaviour

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.js]
+indent_style = space
+indent_size = 2
+

--- a/build-script.sh
+++ b/build-script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm -rf build || true
 rm -rf dist || true

--- a/src/components/user-inputs.js
+++ b/src/components/user-inputs.js
@@ -9,10 +9,11 @@ function registerOn (browserWindow, { viewState }) {
    * Called whenever the mouse is pressed
    */
   function mousePressed () {
-    if (browserWindow.mouseX < 0 || browserWindow.mouseX > viewState.canvasWidth)
+    if (browserWindow.mouseX < 0 || browserWindow.mouseX > viewState.canvasWidth) {
       return
-    if (browserWindow.mouseY < 0 || browserWindow.mouseY > viewState.canvasHeight)
+    } if (browserWindow.mouseY < 0 || browserWindow.mouseY > viewState.canvasHeight) {
       return
+    }
 
     viewState.clickX = browserWindow.mouseX
     viewState.clickY = browserWindow.mouseY
@@ -34,8 +35,9 @@ function registerOn (browserWindow, { viewState }) {
    * Called whenever the mouse is dragged
    */
   function mouseDragged () {
-    if (!viewState.dragActive)
+    if (!viewState.dragActive) {
       return
+    }
 
     const xDif = (browserWindow.mouseX - viewState.clickX)
     const yDif = (browserWindow.mouseY - viewState.clickY)

--- a/src/components/user-inputs.js
+++ b/src/components/user-inputs.js
@@ -9,8 +9,23 @@ function registerOn (browserWindow, { viewState }) {
    * Called whenever the mouse is pressed
    */
   function mousePressed () {
+    if (browserWindow.mouseX < 0 || browserWindow.mouseX > viewState.canvasWidth)
+      return
+    if (browserWindow.mouseY < 0 || browserWindow.mouseY > viewState.canvasHeight)
+      return
+
     viewState.clickX = browserWindow.mouseX
     viewState.clickY = browserWindow.mouseY
+    viewState.dragActive = true
+  }
+
+  /**
+   * P5 MouseReleased
+   *
+   * Called whenever the mouse is released
+   */
+  function mouseReleased () {
+    viewState.dragActive = false
   }
 
   /**
@@ -19,6 +34,9 @@ function registerOn (browserWindow, { viewState }) {
    * Called whenever the mouse is dragged
    */
   function mouseDragged () {
+    if (!viewState.dragActive)
+      return
+
     const xDif = (browserWindow.mouseX - viewState.clickX)
     const yDif = (browserWindow.mouseY - viewState.clickY)
     viewState.clickX = browserWindow.mouseX
@@ -26,6 +44,7 @@ function registerOn (browserWindow, { viewState }) {
     viewState.imageX += xDif
     viewState.imageY += yDif
   }
+
   /**
    * P5 KeyPressed function
    *
@@ -65,6 +84,7 @@ function registerOn (browserWindow, { viewState }) {
   browserWindow.keyPressed = keyPressed
   browserWindow.mouseDragged = mouseDragged
   browserWindow.mousePressed = mousePressed
+  browserWindow.mouseReleased = mouseReleased
 }
 
 export default registerOn


### PR DESCRIPTION
Make viewer only draggable if user clicked into the viewer to start the drag. This way, the viewer doesn't move when a drag is initiated somewhere else on the page (e.g. text selection).